### PR TITLE
Accept any Django 1.11.* version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-Django>=1.8,<=1.11
+Django>=1.8,<1.12
 markdown>=2.6.7


### PR DESCRIPTION
`django-markdown-app` isn't working with any Django 1.11.* version.